### PR TITLE
Use latest version of cebe/markdown library.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
 
 matrix:
   include:
@@ -14,7 +17,7 @@ matrix:
 
 before_script:
   - composer self-update
-  - composer install --prefer-dist --no-interaction --dev
+  - composer install --prefer-dist --no-interaction
   - mysql -e "create database IF NOT EXISTS markdown_test;" -uroot
 
 script:

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "cebe/markdown": "1.x"
     },
     "require-dev": {
-        "cakephp/cakephp": "3.0.*-dev",
+        "cakephp/cakephp": "3.*",
         "phpunit/phpunit": "*",
         "cakephp/cakephp-codesniffer": "dev-master"
     },

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=5.4",
         "cakephp/plugin-installer": "*",
-        "cebe/markdown": "1.0.x"
+        "cebe/markdown": "1.x"
     },
     "require-dev": {
         "cakephp/cakephp": "3.0.*-dev",

--- a/src/View/Helper/MarkdownHelper.php
+++ b/src/View/Helper/MarkdownHelper.php
@@ -37,6 +37,7 @@ class MarkdownHelper extends Helper
             $this->parser = new $className();
             $this->parser->html5 = true;
         }
+
         return $this->parser->parse($input);
     }
 }


### PR DESCRIPTION
The latest 1.2.x release of the cebe/markdown library fixes several issues with GitHub markdown rendering. Update the "require" block in composer.json to use the latest version of cebe/markdown.